### PR TITLE
Adds cython dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN git clone https://github.com/BVLC/caffe
 RUN cd caffe && \
   cp Makefile.config.example Makefile.config && echo "CPU_ONLY := 1" >> Makefile.config && \
   make all -j2 
+RUN pip install cython
 RUN cd caffe && \
   pip install --requirement python/requirements.txt 
 RUN cd caffe && make pycaffe -j2


### PR DESCRIPTION
This change fixes the issue mentioned [here](https://github.com/saturnism/deepdream-docker/issues/2).
I've only used this fix on the [cli version](https://github.com/saturnism/deepdream-cli-docker) of this repository, but the error I ran into was the same as in issue #2.
