### PR TITLE
adds update to pip; adds jupyter dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN git clone https://github.com/BVLC/caffe
 RUN cd caffe && \
   cp Makefile.config.example Makefile.config && echo "CPU_ONLY := 1" >> Makefile.config && \
   make all -j2 
-RUN pip install cython
+RUN pip install -U pip
+RUN pip install cython jupyter
 RUN cd caffe && \
   pip install --requirement python/requirements.txt 
 RUN cd caffe && make pycaffe -j2


### PR DESCRIPTION
Cython was the only dependency needed to get the image to build for the cli version. I had to update `pip` and install `jupyter` in order to get the ipython notebook running locally.

Thanks again for your work on this repo @saturnism.
